### PR TITLE
Use Kramdown for Markdown instead of Redcarpet

### DIFF
--- a/rake-tomdoc.gemspec
+++ b/rake-tomdoc.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.platform   = Gem::Platform::RUBY
   s.name       = "rake-tomdoc"
-  s.version    = "0.0.2"
+  s.version    = "0.0.3"
   s.summary    = "rake-tomdoc"
   s.homepage   = "https://github.com/site5/rake-tomdoc"
   s.authors    = ["Joshua Priddle", "Justin Mazzi"]


### PR DESCRIPTION
Related to #5

Redcarpet uses a C extension, and it seems that jRuby does not have good support for those. This switches it out for Kramdown which is written in pure Ruby.
