### PR TITLE
Require tmpdir

### DIFF
--- a/lib/rake-tomdoc.rb
+++ b/lib/rake-tomdoc.rb
@@ -18,6 +18,8 @@ task :tomdoc do
 
     puts "Generating docs"
 
+    require "tmpdir"
+
     Dir.mktmpdir do |dir|
       cmd "bundle exec yard doc --private --plugin tomdoc " <<
         "--output-dir #{dir} - LICENSE",


### PR DESCRIPTION
`Dir.mktmpdir` needs "tmpdir" to be required under newer Rubies